### PR TITLE
"net-tools" (including netstat) is deprecated

### DIFF
--- a/nsdperfTool.py
+++ b/nsdperfTool.py
@@ -238,13 +238,13 @@ def getNetData(allNodes):
         # TODO
         netData[node] = {}
         retransInfo = chkcmd(
-            "%s %s netstat -s | grep \"segments retransmited\"" % (ssh, node))
+            "%s %s nstat -az TcpRetransSegs" % (ssh, node))
         try:
             netData[node]["retransmit"] = re.search(
-                r"(\d+) segments retransmited", retransInfo).group(1)
+                r"TcpRetransSegs *(\d+)", retransInfo).group(1)
         except Exception:
-            halt("Error, cannot match for retransmit data in \"netstat -s\" "
-                 "output on node %s" % (node))
+            halt("Error, cannot match for retransmit data in "
+                 "\"nstat -az TcpRetransSegs\" output on node %s" % (node))
         ipLinkInfo = chkcmd(
             "%s %s \"ip -s link show %s\"" % (ssh, node, netDev[node]))
         ipLinkFormat = r"RX: bytes  packets  errors  dropped overrun mcast" \


### PR DESCRIPTION
"net-tools" (including netstat) is deprecated and not installed by default on many linux distributions. The replacement package is "iproute". This patch switches from using "netstat" for gathering
number of retransmits, to getting the same information from "nstat", and then avoids the "net-tools" dependency.