### PR TITLE
Fix when running nsdperf over RoCE

### DIFF
--- a/koet.py
+++ b/koet.py
@@ -1312,6 +1312,7 @@ def load_multiple_fping(logdir, hosts_dictionary):
             latencies_list = latencies.split(' ')
             # our mean calculation expect strings. Need to change this when
             # optimizing
+            print(latencies_list)
             mean_all.append(str(mean_list(latencies_list)))
             max_all.append(max(latencies_list))
             min_all.append(min(latencies_list))

--- a/koet.py
+++ b/koet.py
@@ -1312,7 +1312,6 @@ def load_multiple_fping(logdir, hosts_dictionary):
             latencies_list = latencies.split(' ')
             # our mean calculation expect strings. Need to change this when
             # optimizing
-            print(latencies_list)
             mean_all.append(str(mean_list(latencies_list)))
             max_all.append(max(latencies_list))
             min_all.append(min(latencies_list))

--- a/makefile.rdma
+++ b/makefile.rdma
@@ -1,9 +1,9 @@
 # Makefile for net programs
 CXX = g++
-LIBS = -lpthread -lrt
-CFLAGS = -O2
+LIBS = -lpthread -lrt -libverbs -lrdmacm
+CFLAGS = -O2 -DRDMA
 
-PROGS = nsdperf
+PROGS = nsdperf_rdma
 
 all: $(PROGS)
 

--- a/nsdperf.C
+++ b/nsdperf.C
@@ -2992,7 +2992,7 @@ static string rdmaStart()
       if (useCM)
       {
         bool stop = false;
-        for (auto it = portIfSet.begin(); it != portIfSet.end(); ++j)
+        for (auto it = portIfSet.begin(); it != portIfSet.end(); ++it)
         {
           portIf = *it;
           for (ni = netInterfaces.begin(); ni != netInterfaces.end(); ++ni)


### PR DESCRIPTION
The original version used only the first GID of a specific network interface. This fix puts in a vector all GIDs it can find for a given interface, then it finds the first interface name and uses it to run the tests.

In order to show the GIDs of a Mellanox ConnectX-6 adapter use:

[root@localhost ~]# show_gids mlx5_0
DEV     PORT    INDEX   GID                                     IPv4            VER     DEV
---     ----    -----   ---                                     ------------    ---     ---
mlx5_0  1       0       fe80:0000:0000:0000:0e42:a1ff:fe5d:4db8                 v1      ens1f0
mlx5_0  1       1       fe80:0000:0000:0000:0e42:a1ff:fe5d:4db8                 v2      ens1f0
mlx5_0  1       2       fe80:0000:0000:0000:1186:a6b1:3f0b:c441                 v1      ens1f0
mlx5_0  1       3       fe80:0000:0000:0000:1186:a6b1:3f0b:c441                 v2      ens1f0
mlx5_0  1       4       0000:0000:0000:0000:0000:ffff:ac13:003c 172.19.0.60     v1      ens1f0
mlx5_0  1       5       0000:0000:0000:0000:0000:ffff:ac13:003c 172.19.0.60     v2      ens1f0
n_gids_found=6

Note that in this case the original nsdperf version fails because it uses only the first GID and nsdperf exists with this error below:

[root@localhost ~]# ./nsdperf-rdma -r mlx5_0/1 -s -d
05:32:39.904017 nsdperf-rdma 1.28 server started
Connection from 172.19.4.2
05:32:49.594867 got msg Version ID 2 len 0 from 172.19.4.2/0
05:32:49.620581 got msg Parms ID 4 len 56 from 172.19.4.2/0
05:32:49.642896 RDMA port mlx5_0:1 has no address
05:32:49.643393 sending msg ReplyErr ID 4 len 24 to 172.19.4.2/0
05:33:22.192687 got msg Kill ID 6 len 0 from 172.19.4.2/0
Connection to 172.19.4.2/0 broken
05:33:22.193039 Closed connection to 172.19.4.2/0

