### PR TITLE
Fix nsdperf RDMA async poll rebuild

### DIFF
--- a/nsdperf.C
+++ b/nsdperf.C
@@ -8153,6 +8153,11 @@ int RdmaAsync::threadBody()
     // If device table size changes, rebuild the poll list
     if (rdmaDevTab.size() != lastDevCount)
     {
+      // The async fd is non-blocking; stale duplicate entries can make one
+      // event look readable more than once and turn the second drain into EAGAIN.
+      rdevList.clear();
+      fdList.clear();
+
       rdevList.reserve(rdmaDevTab.size());
       fdList.reserve(rdmaDevTab.size());
       pfd.events = POLLIN;
@@ -8176,6 +8181,7 @@ int RdmaAsync::threadBody()
       rdevList.push_back(NULL);
       pfd.fd = asyncSocks[0];
       fdList.push_back(pfd);
+      lastDevCount = rdmaDevTab.size();
     }
 
     // Poll for an event on one of the RDMA devices


### PR DESCRIPTION
RdmaAsync::threadBody() rebuilt its poll lists whenever rdmaDevTab.size() differed from lastDevCount, but never updated lastDevCount and never cleared the existing lists before appending. Duplicate nonblocking async FDs could accumulate, so a repeated CLIENT_REREGISTER event could cause a second ibv_get_async_event() call on an already-drained event, returning EAGAIN and terminating nsdperf.

Clear the RDMA device and pollfd lists before repopulating them and record the device count after rebuilding.